### PR TITLE
Riotjs Tabs Implementation

### DIFF
--- a/src/tags/section-schedule.html
+++ b/src/tags/section-schedule.html
@@ -9,16 +9,16 @@
 
       <!-- Nav tabs -->
       <ul class="nav nav-tabs schedule_tabs" role="tablist">
-        <li role="presentation" each="{day, idx in app.schedule}" class="{idx === 0 ? 'active' : ''}">
-          <a href="#day{idx}" aria-controls="day{idx}" role="tab" data-toggle="tab">
+        <li role="presentation" each="{day, idx in app.schedule}" class="{active: idx === 0}">
+          <a href="#tab-content" aria-controls="day{idx}" role="tab" onClick="{tab.onClick}">
             {day.name}<br><span>{day.date}</span>
           </a>
         </li>
       </ul>
 
       <!-- Tab panes -->
-      <div class="tab-content">
-        <div role="tabpanel" class="tab-pane {idx === 0 ? 'in active' : ''}" each="{day, idx in app.schedule}" id="day{idx}">
+      <div class="tab-content" id="tab-content">
+        <div role="tabpanel" class="tab-pane {active: idx === 0}" each="{day, idx in app.schedule}" data-tab-id="day{idx}">
           <div class="schedule_item {session.solo ? 'col-md-12' : 'col-md-6'} {session.type}" each="{session in day.sessions}">
             <div class="panel-heading">
               <div class="speakers">{session.speaker}</div>
@@ -41,5 +41,37 @@
   </div>
 
   <script type="text/javascript">
+    var tag = this;
+
+    this.tab = {
+      onClick: function onClick(event) {
+        event.preventDefault();
+        event.preventUpdate = true;
+
+        this.tab.clear();
+        this.tab.show(event.target);
+      },
+      clear: function clear() {
+        tag.root.querySelectorAll('[role="presentation"], [role="tab"], [role="tabpanel"]')
+          .forEach(function (element) {
+            element.classList.remove('active');
+
+            if (element.hasAttribute('aria-expanded')) {
+              element.setAttribute('aria-expanded', false);
+            }
+            if (element.hasAttribute('aria-selected')) {
+              element.setAttribute('aria-selected', false);
+            }
+          });
+      },
+      show: function show(tab) {
+        tab = $(tab).closest('[role="tab"]')[0];
+        var pane = tag.root.querySelector('[data-tab-id="' + tab.getAttribute('aria-controls') + '"]');
+        pane.classList.add('active');
+        pane.setAttribute('aria-expanded', true);
+
+        $(tab).closest('[role="presentation"]')[0].setAttribute('aria-selected', true);
+      }
+    };
   </script>
 </section-schedule>


### PR DESCRIPTION
fixes https://github.com/franksworld/phpdetroit.io/issues/19

https://www.npmjs.com/package/smooth-scroll#styling-with-ids was removing the `id` from the tab pane when the tab was clicked, which prevented subsequent clicks from finding the desired pane. Also note https://github.com/cferdinandi/smooth-scroll/issues/411 which may be contributing.

Implemented a riot version instead using `data-tab-id`.  Not good for accessibility, but works properly.